### PR TITLE
remove deprecated exports autocomplete extenstion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,6 @@ your imports.
 
 <hr>
 
-### [Exports Autocomplete](https://marketplace.visualstudio.com/items?itemName=capaj.vscode-exports-autocomplete)
-
-Still importing components manually? Why? Just use the component in your JSX and
-this extension will import it for you.
-
-![Exports Autocomplete](https://i.imgur.com/TM6l3o6.gif)
-
-<hr>
-
 ### [CSS2React](https://marketplace.visualstudio.com/items?itemName=gottfired.css2react)
 
 You know how you copy/paste in some CSS to a React component, then you gotta fix

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "xabikos.javascriptsnippets",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
-    "capaj.vscode-exports-autocomplete",
     "gottfired.css2react",
     "christian-kohler.npm-intellisense",
     "angryobject.react-pure-to-class-vscode"


### PR DESCRIPTION
As mentioned in #6 this extension is deprecated, what's more, it is not working correctly in some cases (double comma from https://github.com/microsoft/TypeScript/issues/40561). So, I allowed myself to create simple PR to remove it from the dependencies list.